### PR TITLE
fix(chainlink-data-feed): graceful no-op deploy instead of crashing on removed your-contract

### DIFF
--- a/extensions/packages/stylus/scripts/deploy.ts
+++ b/extensions/packages/stylus/scripts/deploy.ts
@@ -1,0 +1,8 @@
+import { DeployOptions } from "./utils/type";
+
+export default async function deployScript(deployOptions: DeployOptions) {
+  void deployOptions;
+  console.log(
+    "ℹ️  chainlink-data-feed has no Stylus contract to deploy — this extension reads an existing on-chain Chainlink price feed (see packages/nextjs/contracts/externalContracts.ts). Nothing to deploy. Run yarn start to use the UI.",
+  );
+}


### PR DESCRIPTION
## Root Cause

`chainlink-data-feed` is intentionally frontend-only — it reads an existing on-chain Chainlink price-feed aggregator via `packages/nextjs/contracts/externalContracts.ts` and ships no Stylus contract of its own.

The base scaffold's `packages/stylus/scripts/deploy.ts` hardcodes `contract: 'your-contract'`. When `scaffold-stylus -e chainlink-data-feed` is applied, `your-contract` is removed but the base `deploy.ts` is not overridden, so `yarn deploy` crashes:

```
Error: Cargo.toml not found in contract folder: contracts/your-contract/Cargo.toml
```

This looks broken when in reality there is simply nothing to deploy.

## Fix

Adds `extensions/packages/stylus/scripts/deploy.ts` — a clean no-op override that:
- Exports the same `default async function deployScript(deployOptions: DeployOptions)` signature
- Imports `DeployOptions` from `'./utils/type'` (matches base import style)
- Prints a clear, friendly explanation and returns without throwing (exit 0)
- Uses `void deployOptions` to satisfy lint while keeping the required signature
- Does **not** call `deployStylusContract` or reference `your-contract`

## Pattern Match

Mirrors the override pattern used by `chainlink-vrf`, which ships its own `extensions/packages/stylus/scripts/deploy.ts`. `chainlink-data-feed` was the only extension missing this override.

## Change

One file added: `extensions/packages/stylus/scripts/deploy.ts` (8 lines). No other files touched.